### PR TITLE
Add progress bar when downloading

### DIFF
--- a/download.go
+++ b/download.go
@@ -49,11 +49,15 @@ func (p *progressBar) update() {
 	sendMessage(
 		"update",
 		fmt.Sprintf(
-			"%2d%% Downloaded: %s of %s (%s/sec)",
+			`{"msg": "%s", "pct": %2d}`,
+			fmt.Sprintf(
+				"%2d%% Downloaded: %s of %s (%s/sec)",
+				pct,
+				humanize.Bytes(uint64(p.current)),
+				humanize.Bytes(uint64(p.total)),
+				humanize.Bytes(uint64(p.snapRate)),
+			),
 			pct,
-			humanize.Bytes(uint64(p.current)),
-			humanize.Bytes(uint64(p.total)),
-			humanize.Bytes(uint64(p.snapRate)),
 		),
 	)
 }

--- a/download.go
+++ b/download.go
@@ -48,8 +48,10 @@ func (p *progressBar) update() {
 	}
 	sendMessage(
 		"update",
-		fmt.Sprintf(
-			`{"msg": "%s", "pct": %2d}`,
+		struct {
+			Msg string `json:"msg"`
+			Pct int    `json:"pct"`
+		} {
 			fmt.Sprintf(
 				"%2d%% Downloaded: %s of %s (%s/sec)",
 				pct,
@@ -58,7 +60,7 @@ func (p *progressBar) update() {
 				humanize.Bytes(uint64(p.snapRate)),
 			),
 			pct,
-		),
+		},
 	)
 }
 

--- a/resources/app/index.html
+++ b/resources/app/index.html
@@ -16,6 +16,7 @@
         <button id="download-button" type="button" style="width: 26%; margin-left: 1%; margin-right: 1%;"
             disabled="disabled">Download</button>
     </form>
+    <progress id="download-progress" max="100" style="display:none;"></progress>
     <div id="update-status"></div>
     <script src="static/js/index.js"></script>
     <script src="static/lib/astiloader/astiloader.js"></script>

--- a/resources/app/static/css/base.css
+++ b/resources/app/static/css/base.css
@@ -12,17 +12,11 @@ body {
     padding: 1em;
 }
 
-#update-status {
-    border-top: 1px solid gray;
-    padding: 1em;
-    text-align: center;
-}
-
-input: {
+input {
     border: 2px solid black;
 }
 
-button: {
+button {
     border: 2px solid black;
     color: black;
     background-color: lightgray;
@@ -31,4 +25,8 @@ button: {
 button:disabled {
     color: gray;
     opacity: 0.25;
+}
+
+#download-progress {
+    width: 100%;
 }

--- a/resources/app/static/js/index.js
+++ b/resources/app/static/js/index.js
@@ -1,8 +1,14 @@
 let index = {
     isDownloading: false,
-	update: function( msg ) {
+	update: function( message, data ) {
 		let div = document.getElementById("update-status");
-		div.innerHTML = msg;
+        div.innerHTML = message;
+
+        if ( data && data .pct ) {
+            document
+                .querySelector( '#download-progress' )
+                .setAttribute( 'value', data.pct );
+        }
 	},
     append: function( msg ) {
         let div = document.createElement("div");
@@ -64,6 +70,7 @@ let index = {
             	index.update("OK. Attempting to download")
             	document.getElementById("download-button").disabled = true;
             }
+            document.querySelector('#download-progress').removeAttribute('style');
             index.send("download", { url: document.getElementById("url-input").value, save: path })
     	});
     },
@@ -76,7 +83,12 @@ let index = {
     listen: function() {
         astilectron.onMessage(function(message) {
                 if ( "update" === message.name ) {
-                        index.update(message.payload)
+                    try {
+                        const payload = JSON.parse( message.payload );
+                        index.update( payload.msg, { pct: payload.pct } );
+                    } catch ( e ) {
+                        // invalid payload
+                    }
                 } else if ( "complete" === message.name ) {
                     index.update("Finished downloading media export!");
                 } else {

--- a/resources/app/static/js/index.js
+++ b/resources/app/static/js/index.js
@@ -82,20 +82,20 @@ let index = {
     },
     listen: function() {
         astilectron.onMessage(function(message) {
-                if ( "update" === message.name ) {
-                    try {
-                        const payload = JSON.parse( message.payload );
-                        index.update( payload.msg, { pct: payload.pct } );
-                    } catch ( e ) {
-                        // invalid payload
-                    }
-                } else if ( "complete" === message.name ) {
-                    index.update("Finished downloading media export!");
+            console.log( message );
+            console.log( message.payload );
+            if ( "update" === message.name ) {
+                if ( 'string' === typeof message.payload ) {
+                    index.update( message.payload );
                 } else {
-        	        index.append(JSON.stringify(message))
+                    index.update( message.payload.msg, message.payload );
                 }
-                // {"name":"update","payload":"got request for download"}
-
+            } else if ( "complete" === message.name ) {
+                index.update("Finished downloading media export!");
+            } else {
+                index.append(JSON.stringify(message))
+            }
+            // {"name":"update","payload":"got request for download"}
         });
     },
     // match go/humanize

--- a/resources/app/static/js/index.js
+++ b/resources/app/static/js/index.js
@@ -82,8 +82,6 @@ let index = {
     },
     listen: function() {
         astilectron.onMessage(function(message) {
-            console.log( message );
-            console.log( message.payload );
             if ( "update" === message.name ) {
                 if ( 'string' === typeof message.payload ) {
                     index.update( message.payload );


### PR DESCRIPTION
Resolves #3 - well, the progress bar part.

 - changes the message format from the server so that the server sends a JSON-serialized string
 - I'm guessing this is done for me in Go and I'm doing it manually like a doofus, that would be a good way to make this patch better