### PR TITLE
Show download size before downloading

### DIFF
--- a/resources/app/static/js/index.js
+++ b/resources/app/static/js/index.js
@@ -1,4 +1,5 @@
 let index = {
+    isDownloading: false,
 	update: function( msg ) {
 		let div = document.getElementById("update-status");
 		div.innerHTML = msg;
@@ -25,13 +26,31 @@ let index = {
     	index.update("2");
     	if ( /^https?:\/\/[^\/]+\/media-export\.php\?/.test(url) ) {
     		document.getElementById("download-button").disabled = false;
-    		index.update("Press download to choose a filename to save the export as and begin the download")
+            index.update("Press download to choose a filename to save the export as and begin the download")
+
+            const xhr = new XMLHttpRequest();
+            xhr.open( 'HEAD', url );
+            xhr.onload = () => {
+                if ( index.isDownloading ) {
+                    // too late, don't overwrite following messages
+                    return;
+                }
+
+                const fileSize = parseInt( xhr.getResponseHeader( 'Content-length' ), 10 );
+
+                index.update(
+                    'Press download to choose a filename to save ' +
+                    'the export as and begin the download: ' + index.humanSize( fileSize )
+                );
+            };
+            xhr.send();
     	} else {
     		document.getElementById("download-button").disabled = true;
             index.update("Enter a valid WordPress.com media export URL to begin")
     	}
     },
     download: function(event) {
+        index.isDownloading = true;
 		asticode.loader.show();
     	let url = document.getElementById("url-input").value;
     	let dom = url.match(/^https?:\/\/([^\/]+)\/media-export\.php\?/)[1]
@@ -64,6 +83,31 @@ let index = {
                 // {"name":"update","payload":"got request for download"}
 
         });
+    },
+    // match go/humanize
+    humanSize: function( size ) {
+        const prefixes = {
+            '0': '',
+            '3': 'k',
+            '6': 'M',
+            '9': 'G',
+            '12': 'T'
+        };
+
+        if ( size === 0 ) {
+            return '0';
+        }
+
+        const mag = size;
+        let exp = Math.floor( Math.floor( Math.log10( size ) ) / 3 ) * 3;
+        let value = mag / Math.pow( 10, exp );
+
+        if ( value === 1000 ) {
+            exp += 3;
+            value = mag / Math.pow( 10, exp );
+        }
+
+        return `${ Math.round( value * 10 ) / 10 } ${ prefixes[ exp ] }B`;
     }
 };
 window.index = index;


### PR DESCRIPTION
Resolves #5 

Once someone enters a valid-looking URL perform a HEAD from
within the browser to determine file-size of media download
and append it to the status message.

Doesn't update message if someone clicks on the download button
before the `HEAD` request returns.

Doesn't handle failure of `HEAD` request.